### PR TITLE
Add support for fs.FS file system support

### DIFF
--- a/asig/material.go
+++ b/asig/material.go
@@ -6,8 +6,7 @@ package asig
 #cgo windows,amd64 LDFLAGS: -l assimp_windows_amd64
 #cgo darwin,arm64 LDFLAGS: -l assimp_darwin_arm64
 
-#include "wrap.c"
-#include <stdlib.h>
+#include "wrap.h"
 */
 import "C"
 import (

--- a/asig/wrap.c
+++ b/asig/wrap.c
@@ -1,3 +1,50 @@
-#include <assimp/cimport.h>        // Plain-C interface
-#include <assimp/scene.h>          // Output data structure
-#include <assimp/postprocess.h>
+#include "wrap.h"
+#include <stdio.h>
+
+extern C_STRUCT aiFile *go_aiFileOpenProc(C_STRUCT aiFileIO *io, char *name, char *flags);
+C_STRUCT aiFile *cgo_aiFileOpenProc(C_STRUCT aiFileIO *io, const char *name, const char *flags)
+{
+	return go_aiFileOpenProc(io, (char *)name, (char *)flags);
+}
+
+extern void go_aiFileCloseProc(C_STRUCT aiFileIO *io, C_STRUCT aiFile *file);
+void cgo_aiFileCloseProc(C_STRUCT aiFileIO *io, C_STRUCT aiFile *file)
+{
+	go_aiFileCloseProc(io, file);
+}
+
+extern size_t go_aiFileWriteProc(C_STRUCT aiFile *file, const char *buffer, size_t size, size_t count);
+size_t cgo_aiFileWriteProc(C_STRUCT aiFile *file, const char *buffer, size_t size, size_t count)
+{
+	return go_aiFileWriteProc(file, (char *)buffer, size, count);
+}
+
+extern size_t go_aiFileReadProc(C_STRUCT aiFile *, char *, size_t, size_t);
+size_t cgo_aiFileReadProc(C_STRUCT aiFile *file, char *buffer, size_t size, size_t count)
+{
+	return go_aiFileReadProc(file, buffer, size, count);
+}
+
+extern size_t go_aiFileTellProc(C_STRUCT aiFile *file);
+size_t cgo_aiFileTellProc(C_STRUCT aiFile *file)
+{
+	return go_aiFileTellProc(file);
+}
+
+extern size_t go_aiFileFileSizeProc(C_STRUCT aiFile *file);
+size_t cgo_aiFileFileSizeProc(C_STRUCT aiFile *file)
+{
+	return go_aiFileFileSizeProc(file);
+}
+
+extern void go_aiFileFlushProc(C_STRUCT aiFile *file);
+void cgo_aiFileFlushProc(C_STRUCT aiFile *file)
+{
+	go_aiFileFlushProc(file);
+}
+
+extern C_ENUM aiReturn go_aiFileSeekProc(C_STRUCT aiFile *file, size_t offset, C_ENUM aiOrigin origin);
+C_ENUM aiReturn cgo_aiFileSeekProc(C_STRUCT aiFile *file, size_t offset, C_ENUM aiOrigin origin)
+{
+	return go_aiFileSeekProc(file, offset, origin);
+}

--- a/asig/wrap.h
+++ b/asig/wrap.h
@@ -1,0 +1,20 @@
+#ifndef WRAP_H
+#define WRAP_H
+
+#include <assimp/cimport.h> // Plain-C interface
+#include <assimp/cfileio.h> // Plain-C interface
+#include <assimp/scene.h>	// Output data structure
+#include <assimp/postprocess.h>
+#include <stdlib.h>
+
+C_STRUCT aiFile *cgo_aiFileOpenProc(C_STRUCT aiFileIO *io, const char *name, const char *flags);
+void cgo_aiFileCloseProc(C_STRUCT aiFileIO *io, C_STRUCT aiFile *file);
+
+size_t cgo_aiFileWriteProc(C_STRUCT aiFile *, const char *, size_t, size_t);
+size_t cgo_aiFileReadProc(C_STRUCT aiFile *, char *, size_t, size_t);
+size_t cgo_aiFileTellProc(C_STRUCT aiFile *);
+size_t cgo_aiFileFileSizeProc(C_STRUCT aiFile *);
+void cgo_aiFileFlushProc(C_STRUCT aiFile *);
+C_ENUM aiReturn cgo_aiFileSeekProc(C_STRUCT aiFile *, size_t, C_ENUM aiOrigin);
+
+#endif

--- a/main.go
+++ b/main.go
@@ -4,13 +4,16 @@ import (
 	"bytes"
 	"fmt"
 	"image/png"
+	"os"
 
 	"github.com/bloeys/assimp-go/asig"
 )
 
 func main() {
 
-	scene, release, err := asig.ImportFile("obj.obj", asig.PostProcessTriangulate|asig.PostProcessJoinIdenticalVertices)
+	//scene, release, err := asig.ImportFile("obj.obj", asig.PostProcessTriangulate|asig.PostProcessJoinIdenticalVertices)
+	fsys := os.DirFS(".")
+	scene, release, err := asig.ImportFileEx("obj.obj", asig.PostProcessTriangulate|asig.PostProcessJoinIdenticalVertices, fsys)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Adds support for asig.ImportFileEx, which accepts an fs.FS.  This allows asig to load from go fs implementations.